### PR TITLE
Fix 'Use of uninitialized value $case in concatenation or string'

### DIFF
--- a/lib/Error/Base.pm
+++ b/lib/Error/Base.pm
@@ -534,8 +534,7 @@ sub put_indent {
 # For internal use only
 sub _fix_pre_ind {
     my $self            = shift;
-    my $indent          ;
-    my $case            ;
+    my $case            = q{};
     
     $case   = $case . ( defined $self->{-prepend} ? 'P' : '-' );
     $case   = $case . ( defined $self->{-indent}  ? 'I' : '-' );


### PR DESCRIPTION
`_fix_pre_ind()` declares (but not defines) a `$case` that is concatenated to in the next line, so initialize `$case` with an empty string to silence this warning.